### PR TITLE
Improve SC timestamp timezone handling

### DIFF
--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -65,7 +65,7 @@ SCTS.prototype.getTime = function()
 SCTS.prototype._getDateTime = function()
 {
     var dt = new Date(this.getTime() * 1000);
-    return printf(
+    return sprintf(
         '%02d%02d%02d%02d%02d%02d00', 
         dt.getYear(),
         dt.getMonth() + 1,

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -46,14 +46,12 @@ SCTS.parse = function()
         );
     });
 
-    var year   = 2000 + params.shift();
-    var month  = params.shift();
-    var day    = params.shift();
-    var hour   = params.shift();
-    var minute = params.shift();
-    var second = params.shift();
+    /* Build ISO8601 datetime string in the YYYY-MM-DDTHH:mm:ss format */
+    var isoStr = sprintf('%d-%02d-%02dT%02d:%02d:%02d',
+                         params[0] > 70 ? 1900 + params[0] : 2000 + params[0],
+                         params[1], params[2], params[3], params[4], params[5]);
     
-    var date = new Date(year, month-1, day, hour, minute, second);
+    var date = new Date(isoStr);
     
     return new SCTS(date);
 };

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -82,15 +82,25 @@ SCTS.prototype.getTzOff = function()
  */
 SCTS.prototype._getDateTime = function()
 {
-    var dt = new Date(this.getTime() * 1000);
+    /**
+     * Since the JS can not output time in the specified TimeZone we first
+     * manually shift the UTC timestamp onto tzOffset and then use
+     * getUTC{Year,Month,etc.}() methods to get a Year, Month, etc.
+     */
+    var tz = this.getTzOff();
+    var dt = new Date((this.getTime() + tz * 60) * 1000);
+
+    tz = Math.floor(tz / 15);   /* To quarters of an hour */
     return sprintf(
-        '%02d%02d%02d%02d%02d%02d00', 
-        dt.getYear(),
-        dt.getMonth() + 1,
-        dt.getDate(),
-        dt.getHours(),
-        dt.getMinutes(),
-        dt.getSeconds()
+        '%02d%02d%02d%02d%02d%02d%02X',
+        dt.getUTCFullYear() % 100,
+        dt.getUTCMonth() + 1,
+        dt.getUTCDate(),
+        dt.getUTCHours(),
+        dt.getUTCMinutes(),
+        dt.getUTCSeconds(),
+        Math.floor(Math.abs(tz / 10)) * 16 + tz % 10 +
+        (tz < 0 ? 0x80 : 0x00)
     );
 };
 

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -35,13 +35,16 @@ SCTS.parse = function()
     }
 
     hex.match(/.{1,2}/g).map(function(s){
-        if(/\D+/.test(s)){
+        /* NB: 7'th element (index = 6) is TimeZone and it can be a HEX */
+        if((params.length < 6 && /\D+/.test(s)) ||
+           (params.length == 6 && /[^0-9A-Fa-f]/.test(s))){
             return params.push(0);
         }
 
         params.push(
             parseInt(
-                s.split("").reverse().join("")
+                s.split("").reverse().join(""),
+                params.length < 6 ? 10 : 16
             )
         );
     });

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -88,6 +88,25 @@ SCTS.prototype.getTzOff = function()
 };
 
 /**
+ * returns ISO8601 formated datetime string
+ * @return string
+ */
+SCTS.prototype.getIsoString = function()
+{
+    /**
+     * Since the JS can not output time in the specified TimeZone we first
+     * manually shift the UTC timestamp onto tzOffset then use standard
+     * method to get an ISO8601 string and then manually replace 'Z' suffix
+     * (which is indicating UTC timezone) by the real TimeZone offset.
+     */
+    var tz = this.getTzOff();
+    var dt = new Date((this.getTime() + tz * 60) * 1000);
+
+    return sprintf("%.19s%s%02u:%02u", dt.toISOString(), tz < 0 ? '-' : '+',
+                   Math.floor(Math.abs(tz) / 60), tz % 60);
+};
+
+/**
  * format datatime for split
  * @return string
  */

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -3,13 +3,22 @@
 var PDU     = require('../pdu'),
     sprintf = require('sprintf');
     
-function SCTS(date)
+function SCTS(date, tzOff)
 {
     /**
      * unix time
      * @var integer
      */
     this._time = date.getTime() / 1000;
+
+    /**
+     * time zone offset, in minutes
+     * @var integer
+     */
+    if (tzOff === undefined)
+        this._tzOff = -1 * date.getTimezoneOffset();
+    else
+        this._tzOff = tzOff;
 }
 
 /**
@@ -56,6 +65,15 @@ SCTS.parse = function()
 SCTS.prototype.getTime = function()
 {
     return this._time;
+};
+
+/**
+ * getter tzOff
+ * @return integer
+ */
+SCTS.prototype.getTzOff = function()
+{
+    return this._tzOff;
 };
 
 /**

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -34,17 +34,17 @@ SCTS.parse = function()
         throw new Error("Not enough bytes");
     }
 
-        hex.match(/.{1,2}/g).map(function(s){
-            if(/\D+/.test(s)){
-                return params.push(0);
-            }
+    hex.match(/.{1,2}/g).map(function(s){
+        if(/\D+/.test(s)){
+            return params.push(0);
+        }
 
-            params.push(
-                parseInt(
-                    s.split("").reverse().join("")
-                )
-            );
-        });
+        params.push(
+            parseInt(
+                s.split("").reverse().join("")
+            )
+        );
+    });
 
     var year   = 2000 + params.shift();
     var month  = params.shift();

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -86,9 +86,7 @@ SCTS.prototype.toString = function()
     return this._getDateTime()
         .match(/.{1,2}/g)
         .map(function(s){
-            return parseInt(
-                s.split("").reverse().join("")
-            );
+            return s.split("").reverse().join("")
         }).join("");
 };
 

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -53,10 +53,20 @@ SCTS.parse = function()
     var isoStr = sprintf('%d-%02d-%02dT%02d:%02d:%02d',
                          params[0] > 70 ? 1900 + params[0] : 2000 + params[0],
                          params[1], params[2], params[3], params[4], params[5]);
+
+    /* Parse TimeZone field (see 3GPP TS 23.040 section 9.2.3.11) */
+    var tzOff = params[6] & 0x7f;
+    tzOff = (tzOff >> 4) * 10 + (tzOff & 0x0f); /* Semi-octet to int */
+    tzOff = tzOff * 15;                         /* Quarters of an hour to minutes */
+    if (params[6] & 0x80)                       /* Check sign */
+        tzOff *= -1;
+
+    isoStr += sprintf('%s%02d:%02d', tzOff < 0 ? '-' : '+',
+                      Math.floor(Math.abs(tzOff / 60)), tzOff % 60);
     
     var date = new Date(isoStr);
     
-    return new SCTS(date);
+    return new SCTS(date, tzOff);
 };
 
 /**

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ pdu.parse('06918919015000240C9189194238148900003110211052254117CAB03D3C1FCBD3703
 * methods:
  * constructor(Date date) // 
  * [Integer] getTime()
+ * [Integer] getTzOff() // get time zone offset, in minutes
 
 ### SCA 
 ### SCA/Type

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ pdu.parse('06918919015000240C9189194238148900003110211052254117CAB03D3C1FCBD3703
  * constructor(Date date) // 
  * [Integer] getTime()
  * [Integer] getTzOff() // get time zone offset, in minutes
+ * [String] getIsoString // get ISO8601 formated date and time (YYYY-MM-DDTHH:mm:ss±hh:mm)
 
 ### SCA 
 ### SCA/Type


### PR DESCRIPTION
This changes set makes the SCTS class timezone aware:
* use timezone during timestamp parsing;
* add a timezone tacking by keeping it in the internal field;
* add a public method to obtain timestamp with the timezone offset (in ISO8601 format).

This should help with handling of SMS(s) which is received from a different timezone and could facilitate timestamp extraction and keeping since we no more loss timezone info.

Also this changes set fixes a couple of tiny internal issues: crash, symbol loss, etc.