### PR TITLE
SCA: few parser fixes

### DIFF
--- a/PDU/SCA.js
+++ b/PDU/SCA.js
@@ -88,14 +88,15 @@ SCA.parse = function(isAddress)
                     hex.match(/.{1,2}/g).map(function(b){
                         return SCA._map_filter_decode(b)
                                 .split("").reverse().join("");
-                    }).join("")
+                    }).join(""),
+                    !isAddress
                 );
 
                 break;
 
             case Type.TYPE_ALPHANUMERICAL:
 
-                sca.setPhone(Helper.decode7Bit(hex));
+                sca.setPhone(Helper.decode7Bit(hex), !isAddress);
 
                 break;
 

--- a/PDU/SCA.js
+++ b/PDU/SCA.js
@@ -55,19 +55,23 @@ SCA.parse = function(isAddress)
     
     var buffer = new Buffer(PDU.getPduSubstr(2), 'hex');
     var sca  = new SCA(isAddress),
-        size = buffer[0];
+        size = buffer[0],
+        octets;
 
     if(size){
 
         // if is OA or DA size in digits
         if(isAddress){
             if((size % 2) !== 0){
-                size++;
+                octets = size + 1;
+            } else {
+                octets = size;
             }
         // else size in octets
         } else {
             size--;
             size *= 2;
+            octets = size;
         }
 
         buffer = new Buffer(PDU.getPduSubstr(2), 'hex');
@@ -75,7 +79,7 @@ SCA.parse = function(isAddress)
             new Type(buffer[0])
         );
 
-        var hex = PDU.getPduSubstr(size);
+        var hex = PDU.getPduSubstr(octets);
 
         switch(sca.getType().getType()){
             case Type.TYPE_UNKNOWN: 
@@ -84,11 +88,14 @@ SCA.parse = function(isAddress)
             case Type.TYPE_SUBSCRIBER_NET:
             case Type.TYPE_TRIMMED:
 
+                if (!isAddress && hex.charAt(size - 2) == 'F')  /* Detect padding char */
+                    size--;
+
                 sca.setPhone(
                     hex.match(/.{1,2}/g).map(function(b){
                         return SCA._map_filter_decode(b)
                                 .split("").reverse().join("");
-                    }).join(""),
+                    }).join("").slice(0, size),
                     !isAddress
                 );
 


### PR DESCRIPTION
This changes set contains fixes for the padding semi-octet removing and for the SCA length corruption.

With this change the getPhone() method returns:
* 31624000000 instead of 31624000000**F** for SCA field value 07911326040000F0
* 31641600986 instead of 31641600986**F** for OA field value 0B911346610089F6

And SCA no more mangled in the following manner: 0**7**911326040000F0 -> 0**B**911326040000F0 if you perform the PDU -> JS Object -> PDU converting circle.

See realization details in the commit message.