### PR TITLE
Parser improvements and misc fixes

### DIFF
--- a/PDU/DCS.js
+++ b/PDU/DCS.js
@@ -21,7 +21,7 @@ function DCS()
      * is compressed text
      * @var boolean
      */
-    this._compressedText = true;
+    this._compressedText = false;
     
     /**
      * Text alphabet
@@ -356,7 +356,7 @@ DCS.prototype.setTextAlphabet = function(alphabet)
     
     switch(this._alphabet){
         case DCS.ALPHABET_DEFAULT:
-            this.setTextCompressed();
+
             break;
         
         case DCS.ALPHABET_8BIT:

--- a/PDU/DCS.js
+++ b/PDU/DCS.js
@@ -133,13 +133,8 @@ DCS.parse = function()
         
         default:
             
-            if(dcs._encodeGroup & (1<<4)){
-                dcs._useMessageClass = true;
-            }
-            
-            if(dcs._encodeGroup & (1<<5)){
-                dcs._compressedText = true;
-            }
+            dcs._useMessageClass = !!(dcs._encodeGroup & (1<<0));
+            dcs._compressedText = !!(dcs._encodeGroup & (1<<1));
     }
     
     if(dcs._discardMessage || dcs._storeMessage || dcs._storeMessageUCS2){
@@ -167,16 +162,12 @@ DCS.prototype.getValue = function()
     
     // set message class bit
     if(this._useMessageClass){
-        this._encodeGroup |= (1<<4);
-    } else {
-        this._encodeGroup &= ~(1<<4);
+        this._encodeGroup |= (1<<0);
     }
     
     // set is compressed bit
     if(this._compressedText){
-        this._encodeGroup |= (1<<5);
-    } else {
-        this._encodeGroup &= ~(1<<5);
+        this._encodeGroup |= (1<<1);
     }
     
     // change encoding format

--- a/PDU/Data.js
+++ b/PDU/Data.js
@@ -69,9 +69,11 @@ Data.parse = function(pdu)
  */
 Data.prototype.append = function(pdu)
 {
+    var self = this;
+
     pdu.getParts().forEach(function(part){
-        if( ! this._partExists(part)){
-            this._parts.push(part);
+        if( ! self._partExists(part)){
+            self._parts.push(part);
         }
     });
     

--- a/PDU/Data.js
+++ b/PDU/Data.js
@@ -95,8 +95,7 @@ Data.prototype._partExists = function(part)
         }
         
         if(_part.getHeader().getCurrent() === part.getHeader().getCurrent()){
-            result = false;
-            return false;
+            result = true;
         }
     });
     

--- a/PDU/Data.js
+++ b/PDU/Data.js
@@ -90,7 +90,8 @@ Data.prototype._partExists = function(part)
 {
     var result = false;
     this._parts.forEach(function(_part){
-        if(part.getHeader().getPointer() !== _part.getHeader().getPointer()){
+        if(part.getHeader().getPointer() !== _part.getHeader().getPointer() ||
+           part.getHeader().getSegments() !== _part.getHeader().getSegments()){
             throw new Error("Part from different message");
         }
         

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -6,22 +6,10 @@ var PDU     = require('../../pdu'),
 function Header(params)
 {
     /**
-     * 
-     * @var integer
-     */
-    this._UDHL     = 6;
-    
-    /**
      *
      * @var integer
      */
-    this._TYPE     = 0x08; // 16bit
-    
-    /**
-     *
-     * @var integer
-     */
-    this._PSIZE    = 4;
+    this._TYPE     = undefined;
     
     /**
      *
@@ -42,11 +30,14 @@ function Header(params)
     this._CURRENT  = 1;
     
     if(params){
+        this._TYPE = Header.IE_CONCAT_16BIT_REF;
         this._SEGMENTS = params.SEGMENTS;
         this._CURRENT  = params.CURRENT;
         this._POINTER  = params.POINTER;
     }
 };
+
+Header.IE_CONCAT_16BIT_REF      = 0x08;
 
 /**
  * parse header
@@ -87,12 +78,12 @@ Header.prototype.toJSON = function()
 };
 
 /**
- * get header size
+ * get header size (UDHL value), in octets
  * @return integer
  */
 Header.prototype.getSize = function()
 {
-    return this._UDHL;
+    return this._TYPE === undefined ? 0 : 6;
 };
 
 /**
@@ -110,7 +101,7 @@ Header.prototype.getType = function()
  */
 Header.prototype.getPointerSize = function()
 {
-    return this._PSIZE;
+    return this._TYPE === undefined ? 0 : 4;
 };
 
 /**
@@ -147,9 +138,13 @@ Header.prototype.getCurrent = function()
 Header.prototype.toString = function()
 {
     var head = '';
-    head += sprintf("%02X", this._UDHL);
+
+    if (this._TYPE === undefined)
+        return '';
+
+    head += sprintf("%02X", 6);
     head += sprintf("%02X", this._TYPE);
-    head += sprintf("%02X", this._PSIZE);
+    head += sprintf("%02X", 4);
     head += sprintf("%04X", this._POINTER);
     head += sprintf("%02X", this._SEGMENTS);
     head += sprintf("%02X", this._CURRENT);

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -6,6 +6,14 @@ var PDU     = require('../../pdu'),
 function Header(params)
 {
     /**
+     * Header Information Elements
+     * Each array element contains at least an IE type and raw IE data in the
+     * form of a hexadecimal string.
+     * @var array
+     */
+    this._ies = [];
+
+    /**
      *
      * @var integer
      */
@@ -30,6 +38,14 @@ function Header(params)
     this._CURRENT  = 1;
     
     if(params){
+        var dataHex = sprintf("%04X%02X%02X",
+                              params.POINTER,
+                              params.SEGMENTS,
+                              params.CURRENT);
+        this._ies.push({
+            type: Header.IE_CONCAT_16BIT_REF,
+            dataHex: dataHex,
+        });
         this._TYPE = Header.IE_CONCAT_16BIT_REF;
         this._SEGMENTS = params.SEGMENTS;
         this._CURRENT  = params.CURRENT;

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -65,9 +65,6 @@ Header.parse = function()
         current   = buffer[1];
     
     var self = new Header({
-            'UDHL':     udhl,
-            'TYPE':     type,
-            'PSIZE':    psize,
             'POINTER':  pointer,
             'SEGMENTS': sergments,
             'CURRENT':  current
@@ -83,9 +80,6 @@ Header.parse = function()
 Header.prototype.toJSON = function()
 {
     return {
-        'UDHL':     this._UDHL,
-        'TYPE':     this._TYPE,
-        'PSIZE':    this._PSIZE,
         'POINTER':  this._POINTER,
         'SEGMENTS': this._SEGMENTS,
         'CURRENT':  this._CURRENT

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -41,11 +41,11 @@ function Header(params)
      */
     this._CURRENT  = 1;
     
-    params = params || {};
-    
-    this._SEGMENTS = params.SEGMENTS || 1;
-    this._CURRENT  = params.CURRENT  || 1;
-    this._POINTER  = params.POINTER  || Math.floor(Math.random() * 0xFFFF);
+    if(params){
+        this._SEGMENTS = params.SEGMENTS;
+        this._CURRENT  = params.CURRENT;
+        this._POINTER  = params.POINTER;
+    }
 };
 
 /**

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -19,24 +19,6 @@ function Header(params)
      */
     this._concatIeIdx = undefined;
     
-    /**
-     *
-     * @var integer
-     */
-    this._POINTER  = 0;
-    
-    /**
-     *
-     * @var integer
-     */
-    this._SEGMENTS = 1;
-    
-    /**
-     *
-     * @var integer
-     */
-    this._CURRENT  = 1;
-    
     if(params){
         var dataHex = sprintf("%04X%02X%02X",
                               params.POINTER,
@@ -45,11 +27,13 @@ function Header(params)
         this._ies.push({
             type: Header.IE_CONCAT_16BIT_REF,
             dataHex: dataHex,
+            data: {
+                msgRef: params.POINTER,
+                maxMsgNum: params.SEGMENTS,
+                msgSeqNo: params.CURRENT
+            }
         });
         this._concatIeIdx = this._ies.length - 1;
-        this._SEGMENTS = params.SEGMENTS;
-        this._CURRENT  = params.CURRENT;
-        this._POINTER  = params.POINTER;
     }
 };
 
@@ -87,9 +71,9 @@ Header.parse = function()
 Header.prototype.toJSON = function()
 {
     return {
-        'POINTER':  this._POINTER,
-        'SEGMENTS': this._SEGMENTS,
-        'CURRENT':  this._CURRENT
+        'POINTER':  this.getPointer(),
+        'SEGMENTS': this.getSegments(),
+        'CURRENT':  this.getCurrent(),
     };
 };
 
@@ -133,7 +117,8 @@ Header.prototype.getPointerSize = function()
  */
 Header.prototype.getPointer = function()
 {
-    return this._POINTER;
+    return this._concatIeIdx === undefined ? 0 :
+           this._ies[this._concatIeIdx].data.msgRef;
 };
 
 /**
@@ -142,7 +127,8 @@ Header.prototype.getPointer = function()
  */
 Header.prototype.getSegments = function()
 {
-    return this._SEGMENTS;
+    return this._concatIeIdx === undefined ? 1 :
+           this._ies[this._concatIeIdx].data.maxMsgNum;
 };
 
 /**
@@ -151,7 +137,8 @@ Header.prototype.getSegments = function()
  */
 Header.prototype.getCurrent = function()
 {
-    return this._CURRENT;
+    return this._concatIeIdx === undefined ? 1 :
+           this._ies[this._concatIeIdx].data.msgSeqNo;
 };
 
 /**

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -14,10 +14,10 @@ function Header(params)
     this._ies = [];
 
     /**
-     *
+     * Index of the concatenation IE
      * @var integer
      */
-    this._TYPE     = undefined;
+    this._concatIeIdx = undefined;
     
     /**
      *
@@ -46,7 +46,7 @@ function Header(params)
             type: Header.IE_CONCAT_16BIT_REF,
             dataHex: dataHex,
         });
-        this._TYPE = Header.IE_CONCAT_16BIT_REF;
+        this._concatIeIdx = this._ies.length - 1;
         this._SEGMENTS = params.SEGMENTS;
         this._CURRENT  = params.CURRENT;
         this._POINTER  = params.POINTER;
@@ -113,7 +113,8 @@ Header.prototype.getSize = function()
  */
 Header.prototype.getType = function()
 {
-    return this._TYPE;
+    return this._concatIeIdx === undefined ? undefined :
+           this._ies[this._concatIeIdx].type;
 };
 
 /**
@@ -122,7 +123,8 @@ Header.prototype.getType = function()
  */
 Header.prototype.getPointerSize = function()
 {
-    return this._TYPE === undefined ? 0 : 4;
+    return this._concatIeIdx === undefined ? 0 :
+           this._ies[this._concatIeIdx].dataHex.length / 2;
 };
 
 /**

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -19,7 +19,34 @@ function Header(params)
      */
     this._concatIeIdx = undefined;
     
-    if(params){
+    if(Array.isArray(params)){
+        /**
+         * NB: This code can be factored out into a separate method if we have
+         * a usecase for it.
+         */
+        for (var ie of params) {
+            var buf = new Buffer(ie.dataHex, 'hex');
+            var data = undefined;
+
+            /* Parse known IEs (e.g. concatenetion) */
+            switch (ie.type) {
+            case Header.IE_CONCAT_16BIT_REF:
+                this._concatIeIdx = this._ies.length;   /* Preserve IE index */
+                data = {
+                    msgRef: (buf[0] << 8) | buf[1],
+                    maxMsgNum: buf[2],
+                    msgSeqNo: buf[3]
+                }
+                break;
+            }
+
+            this._ies.push({
+                type: ie.type,
+                dataHex: ie.dataHex,
+                data: data,
+            });
+        }
+    } else if(params){
         var dataHex = sprintf("%04X%02X%02X",
                               params.POINTER,
                               params.SEGMENTS,

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -30,6 +30,14 @@ function Header(params)
 
             /* Parse known IEs (e.g. concatenetion) */
             switch (ie.type) {
+            case Header.IE_CONCAT_8BIT_REF:
+                this._concatIeIdx = this._ies.length;   /* Preserve IE index */
+                data = {
+                    msgRef: buf[0],
+                    maxMsgNum: buf[1],
+                    msgSeqNo: buf[2]
+                }
+                break;
             case Header.IE_CONCAT_16BIT_REF:
                 this._concatIeIdx = this._ies.length;   /* Preserve IE index */
                 data = {
@@ -64,6 +72,7 @@ function Header(params)
     }
 };
 
+Header.IE_CONCAT_8BIT_REF       = 0x00;
 Header.IE_CONCAT_16BIT_REF      = 0x08;
 
 /**

--- a/PDU/Data/Header.js
+++ b/PDU/Data/Header.js
@@ -99,7 +99,12 @@ Header.prototype.toJSON = function()
  */
 Header.prototype.getSize = function()
 {
-    return this._TYPE === undefined ? 0 : 6;
+    var udhl = 0;
+
+    for (var ie of this._ies)
+        udhl += 2 + ie.dataHex.length / 2;
+
+    return udhl;
 };
 
 /**
@@ -153,19 +158,15 @@ Header.prototype.getCurrent = function()
  */
 Header.prototype.toString = function()
 {
+    var udhl = 0;
     var head = '';
 
-    if (this._TYPE === undefined)
-        return '';
-
-    head += sprintf("%02X", 6);
-    head += sprintf("%02X", this._TYPE);
-    head += sprintf("%02X", 4);
-    head += sprintf("%04X", this._POINTER);
-    head += sprintf("%02X", this._SEGMENTS);
-    head += sprintf("%02X", this._CURRENT);
+    for (var ie of this._ies) {
+        udhl += 2 + ie.dataHex.length / 2;
+        head += sprintf("%02X%02X", ie.type, ie.dataHex.length / 2) + ie.dataHex;
+    }
     
-    return head;
+    return sprintf("%02X", udhl) + head;
 };
 
 module.exports = Header;

--- a/PDU/Data/Part.js
+++ b/PDU/Data/Part.js
@@ -59,6 +59,7 @@ Part.parse = function(data)
     
     var alphabet = data.getPdu().getDcs().getTextAlphabet(),
         header   = null,
+        udl      = data.getPdu().getUdl(),
         length   = data.getPdu().getUdl() * (alphabet === DCS.ALPHABET_UCS2 ? 4 : 2),
         text     = undefined;
     
@@ -89,12 +90,11 @@ Part.parse = function(data)
             throw new Error("Unknown alpabet");
     }
     
-    var size = text.length,
-        self = new Part(data, hex, size, header);
+    var self = new Part(data, hex, udl, header);
     
     self._text = text;
     
-    return [text, size, self];
+    return [text, udl, self];
 };
 
 /**

--- a/PDU/Data/Part.js
+++ b/PDU/Data/Part.js
@@ -62,6 +62,7 @@ Part.parse = function(data)
         udl      = data.getPdu().getUdl(),
         length   = 0,
         hdrSz    = 0,           /* Header full size: UDHL + UDH */
+        alignBits= 0,
         text     = undefined;
 
     if(alphabet == DCS.ALPHABET_DEFAULT)
@@ -82,7 +83,8 @@ Part.parse = function(data)
         case DCS.ALPHABET_DEFAULT:
             PDU.debug("Helper.decode7Bit(" + hex + ")");
             length = udl - Math.ceil(hdrSz * 8 / 7);    /* Convert octets to septets */
-            text = Helper.decode7Bit(hex, length);
+            alignBits = Math.ceil(hdrSz * 8 / 7) * 7 - hdrSz * 8;
+            text = Helper.decode7Bit(hex, length, alignBits);
             break;
         
         case DCS.ALPHABET_8BIT:

--- a/PDU/Data/Part.js
+++ b/PDU/Data/Part.js
@@ -60,15 +60,23 @@ Part.parse = function(data)
     var alphabet = data.getPdu().getDcs().getTextAlphabet(),
         header   = null,
         udl      = data.getPdu().getUdl(),
-        length   = data.getPdu().getUdl() * (alphabet === DCS.ALPHABET_UCS2 ? 4 : 2),
+        length   = 0,
+        hdrSz    = 0,           /* Header full size: UDHL + UDH */
         text     = undefined;
+
+    if(alphabet == DCS.ALPHABET_DEFAULT)
+        length = Math.ceil(udl * 7 / 8);    /* Convert septets to octets */
+    else
+        length = udl;                       /* Length already in octets */
     
     if(data.getPdu().getType().getUdhi()){
         PDU.debug("Header.parse()");
         header = Header.parse();
+        hdrSz = 1 + header.getSize();   /* UDHL field length + UDH length */
+        length -= hdrSz;
     }
     
-    var hex = PDU.getPduSubstr(length);
+    var hex = PDU.getPduSubstr(length * 2); /* Extract Octets x2 chars */
     
     switch(alphabet){
         case DCS.ALPHABET_DEFAULT:

--- a/PDU/Data/Part.js
+++ b/PDU/Data/Part.js
@@ -81,7 +81,8 @@ Part.parse = function(data)
     switch(alphabet){
         case DCS.ALPHABET_DEFAULT:
             PDU.debug("Helper.decode7Bit(" + hex + ")");
-            text = Helper.decode7Bit(hex);
+            length = udl - Math.ceil(hdrSz * 8 / 7);    /* Convert octets to septets */
+            text = Helper.decode7Bit(hex, length);
             break;
         
         case DCS.ALPHABET_8BIT:

--- a/PDU/Data/Part.js
+++ b/PDU/Data/Part.js
@@ -5,6 +5,8 @@ var PDU     = require('../../pdu'),
     
 function Part(parent, data, size, header)
 {
+    var Header = PDU.getModule('PDU/Data/Header');
+
     /**
      * header message
      * @var \Header
@@ -35,9 +37,9 @@ function Part(parent, data, size, header)
      */
     this._parent = parent;
     
-    // have params for header
-    if(header){
-        var Header = PDU.getModule('PDU/Data/Header');
+    if(header instanceof Header){   // have header
+        this._header = header;
+    } else if(header){              // have params for header
         // create header
         this._header = new Header(header);
     }

--- a/PDU/Helper.js
+++ b/PDU/Helper.js
@@ -173,14 +173,19 @@ Helper.encode8Bit = function(text)
 /**
  * encode message
  * @param string $text
+ * @param int $alignBits
  * @return array
  */
-Helper.encode7Bit = function(text)
+Helper.encode7Bit = function(text, alignBits)
 {
     var ret    = "",
         buf    = 0,         /* Bit buffer, used in FIFO manner */
         bufLen = 0,         /* Ammount of buffered bits */
         len    = 0;         /* Ammount of produced septets */
+
+    /* Insert leading alignment zero bits if requested */
+    if(alignBits)
+        bufLen += alignBits;
 
     for (let symb of text) {
         var code;

--- a/PDU/Helper.js
+++ b/PDU/Helper.js
@@ -89,9 +89,10 @@ Helper.decode8Bit = function(text)
  * decode message from 7bit
  * @param string $text
  * @param int $inLen
+ * @param int $alignBits
  * @return string
  */
-Helper.decode7Bit = function(text, inLen)
+Helper.decode7Bit = function(text, inLen, alignBits)
 {
     var ret   = [],
         data  = new Buffer(text, "hex"),
@@ -100,6 +101,14 @@ Helper.decode7Bit = function(text, inLen)
         bufLen = 0,         /* Ammount of buffered bits */
         inDone = 0,
         inExt = false;
+
+    /* If we have some leading alignment bits then skip them */
+    if(alignBits && data.length){
+        alignBits = alignBits % 7;
+        buf = data[dataPos++];
+        buf >>= alignBits;
+        bufLen = 8 - alignBits;
+    }
     
     while (true) {
         if(bufLen < 7){

--- a/PDU/Helper.js
+++ b/PDU/Helper.js
@@ -141,7 +141,11 @@ Helper.decode7Bit = function(text, inLen)
     }
     
     if (inLen !== undefined ? inDone < inLen : carry){
-        ret.push(Helper.ALPHABET_7BIT.charCodeAt(carry));
+        if(inExt){
+            ret.push(Helper.EXTENDED_TABLE.charCodeAt(carry));
+        } else {
+            ret.push(Helper.ALPHABET_7BIT.charCodeAt(carry));
+        }
     }
     
     return (new Buffer(ret, "binary")).toString();

--- a/PDU/Helper.js
+++ b/PDU/Helper.js
@@ -88,15 +88,17 @@ Helper.decode8Bit = function(text)
 /**
  * decode message from 7bit
  * @param string $text
+ * @param int $inLen
  * @return string
  */
-Helper.decode7Bit = function(text)
+Helper.decode7Bit = function(text, inLen)
 {
     var ret   = [],
         data  = new Buffer(text, "hex"),
         mask  = 0xFF,
         shift = 0,
         carry = 0,
+        inDone = 0,
         inExt = false;
     
     for(var i = 0; i < data.length; i++){
@@ -112,6 +114,7 @@ Helper.decode7Bit = function(text)
                     ret.push(Helper.ALPHABET_7BIT.charCodeAt(carry));
                 }
             }
+            inDone++;
             carry = 0;
             shift = 0;
         }
@@ -132,11 +135,12 @@ Helper.decode7Bit = function(text)
                 ret.push(Helper.ALPHABET_7BIT.charCodeAt(digit));
             }
         }
+        inDone++;
 
         shift++;
     }
     
-    if (carry){
+    if (inLen !== undefined ? inDone < inLen : carry){
         ret.push(Helper.ALPHABET_7BIT.charCodeAt(carry));
     }
     

--- a/PDU/SCA.js
+++ b/PDU/SCA.js
@@ -135,14 +135,14 @@ SCA.prototype.setPhone = function(phone, SC)
         Type   = PDU.getModule('PDU/SCA/Type');
     
     this._phone     = phone;
-    var clear       = phone.replace(/[^a-c0-9\*\#]/gi, '');
     this._isAddress = !SC;
     
     if(this.getType().getType() === Type.TYPE_ALPHANUMERICAL){
-        var tmp = Helper.encode7Bit(clear);
-        this._size    = tmp.shift();
+        var tmp = Helper.encode7Bit(phone);
+        this._size    = Math.ceil(tmp.shift() * 7 / 4); /* septets to semi-octets */
         this._encoded = tmp.shift();
     } else {
+        var clear = phone.replace(/[^a-c0-9\*\#]/gi, '');
         
         // get size
         // service center addres counting by octets OA or DA as length numbers
@@ -215,6 +215,8 @@ SCA.prototype.toString = function()
                 // add to pdu
                 str += b2 + b1;
             }
+        } else {
+            str += this._encoded;
         }
     }
     

--- a/PDU/SCA.js
+++ b/PDU/SCA.js
@@ -60,18 +60,14 @@ SCA.parse = function(isAddress)
 
     if(size){
 
-        // if is OA or DA size in digits
+        // if is OA or DA then the size in semi-octets
         if(isAddress){
-            if((size % 2) !== 0){
-                octets = size + 1;
-            } else {
-                octets = size;
-            }
+            octets = Math.ceil(size / 2);   /* to full octets */
         // else size in octets
         } else {
             size--;
-            size *= 2;
             octets = size;
+            size *= 2;          /* to semi-octets for future usage */
         }
 
         buffer = new Buffer(PDU.getPduSubstr(2), 'hex');
@@ -79,7 +75,7 @@ SCA.parse = function(isAddress)
             new Type(buffer[0])
         );
 
-        var hex = PDU.getPduSubstr(octets);
+        var hex = PDU.getPduSubstr(octets * 2);
 
         switch(sca.getType().getType()){
             case Type.TYPE_UNKNOWN: 

--- a/PDU/SCA.js
+++ b/PDU/SCA.js
@@ -103,7 +103,8 @@ SCA.parse = function(isAddress)
 
             case Type.TYPE_ALPHANUMERICAL:
 
-                sca.setPhone(Helper.decode7Bit(hex), !isAddress);
+                size = Math.floor(size * 4 / 7);    /* semi-octets to septets */
+                sca.setPhone(Helper.decode7Bit(hex, size), !isAddress);
 
                 break;
 

--- a/PDU/SCA.js
+++ b/PDU/SCA.js
@@ -142,7 +142,7 @@ SCA.prototype.setPhone = function(phone, SC)
         
         // get size
         // service center addres counting by octets OA or DA as length numbers
-        this._size = SC ? 1 + ((clear.length + 1)/2) : clear.length;
+        this._size = SC ? 1 + Math.ceil(clear.length / 2) : clear.length;
         
         this._encoded = clear.split("").map(function(s){
             return SCA._map_filter_encode(s);

--- a/PDU/SCTS.js
+++ b/PDU/SCTS.js
@@ -117,10 +117,10 @@ SCTS.prototype._getDateTime = function()
      * manually shift the UTC timestamp onto tzOffset and then use
      * getUTC{Year,Month,etc.}() methods to get a Year, Month, etc.
      */
-    var tz = this.getTzOff();
+    var tz = this.getTzOff(), tzAbs = 0;
     var dt = new Date((this.getTime() + tz * 60) * 1000);
 
-    tz = Math.floor(tz / 15);   /* To quarters of an hour */
+    tzAbs = Math.floor(Math.abs(tz) / 15);    /* To quarters of an hour */
     return sprintf(
         '%02d%02d%02d%02d%02d%02d%02X',
         dt.getUTCFullYear() % 100,
@@ -129,7 +129,7 @@ SCTS.prototype._getDateTime = function()
         dt.getUTCHours(),
         dt.getUTCMinutes(),
         dt.getUTCSeconds(),
-        Math.floor(Math.abs(tz / 10)) * 16 + tz % 10 +
+        Math.floor(tzAbs / 10) * 16 + tzAbs % 10 +
         (tz < 0 ? 0x80 : 0x00)
     );
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-pdu",
   "version": "1.0.14",
-  "description": "Create a pdu string for send sms",
+  "description": "Creates and parses a SMS PDU strings",
   "main": "index.js",
   "dependencies": {
 	  "sprintf": "~0.1.5"

--- a/test.js
+++ b/test.js
@@ -127,6 +127,8 @@ var sevenBitEncodingTests = [
         name: '8 symbols', text: 'abcdefgh', code: '61F1985C369FD1',
     }, {
         name: '9 symbols', text: 'abcdefghi', code: '61F1985C369FD169',
+    }, {
+        name: '"@" loss', text: 'abcdefg@', code: '61F1985C369F01', codeLen: 8,
     }
 ];
 
@@ -144,7 +146,7 @@ for (let test of sevenBitEncodingTests) {
         console.log(logPrefix + 'fail: encoder error (text: "' + test.text + '", expecting: "' + test.code + '", got "' + out[1] + '")');
     }
 
-    out = Helper.decode7Bit(test.code);
+    out = Helper.decode7Bit(test.code, test.codeLen);
     if (out != test.text) {
         passed = false;
         console.log(logPrefix + 'fail: decoder error (code: "' + test.code + '", expecting: "' + test.text + '", got "' + out + '")');
@@ -185,6 +187,15 @@ var parserTests = [
                 text: '\u041f\u0440\u0438\u0432\u0435\u0442, \u043c\u0438\u0440!', /* Russian: "Hello, world!" */
             },
         }
+    }, {
+        name: 'Alphanumeric OA',
+        pduStr: '07911326060032F0000DD0D432DBFC96D30100001121313121114012D7327BFC6E9741F437885A669BDF723A',
+        expectedResult: {
+            sca: {isAddress: false, phone: '31626000230'},
+            address: {isAddress: true, phone: 'Telfort'},
+            scts: {isoStr: '2011-12-13T13:12:11+01:00'},
+            data: {text: 'Welcome to Telfort'},
+        },
     }, {
         name: 'Concatenated message #1 (part 1/2) with 16bit ref.',
         pduStr: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',

--- a/test.js
+++ b/test.js
@@ -58,6 +58,14 @@ function verifyResultPdu(logPrefix, res, expRes, err)
             if (!verifyPduValue(logPrefix, 'timestamp', res, 'getScts().getIsoString()', expRes.scts.isoStr))
                 return false;
         }
+        if (expRes.udh !== undefined) {
+            if (!verifyPduValue(logPrefix, 'concat pointer', res, 'getData().getParts()[0].getHeader().getPointer()', expRes.udh.pointer))
+                return false;
+            if (!verifyPduValue(logPrefix, 'concat segments', res, 'getData().getParts()[0].getHeader().getSegments()', expRes.udh.segments))
+                return false;
+            if (!verifyPduValue(logPrefix, 'concat current', res, 'getData().getParts()[0].getHeader().getCurrent()', expRes.udh.current))
+                return false;
+        }
         if (expRes.data !== undefined) {
             if (!verifyPduValue(logPrefix, 'text', res, 'getData().getText()', expRes.data.text))
                 return false;
@@ -141,6 +149,13 @@ var parserTests = [
         name: 'Negative SCTS Time Zone offset',
         pduStr: '07919730071111F1000B919746121611F100008111700212222B0DC8329BFD6681EE6F399B1C02',
         expectedResult: {scts: {isoStr: '2018-11-07T20:21:22-08:00'}},
+    }, {
+        name: 'Concatenated message #1 (part 1/2) with 16bit ref.',
+        pduStr: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',
+        expectedResult: {
+            udh: {pointer: 0x1234, segments: 2, current: 1},
+            data: {text: 'Hello,'},
+        },
     }
 ];
 

--- a/test.js
+++ b/test.js
@@ -86,6 +86,8 @@ function verifyResultPdu(logPrefix, res, expRes, err, expErr)
                 return false;
         }
         if (expRes.data !== undefined) {
+            if (!verifyPduValue(logPrefix, 'data size', res, 'getData().getSize()', expRes.data.size))
+                return false;
             if (!verifyPduValue(logPrefix, 'text', res, 'getData().getText()', expRes.data.text))
                 return false;
         }
@@ -168,6 +170,21 @@ var parserTests = [
         name: 'Negative SCTS Time Zone offset',
         pduStr: '07919730071111F1000B919746121611F100008111700212222B0DC8329BFD6681EE6F399B1C02',
         expectedResult: {scts: {isoStr: '2018-11-07T20:21:22-08:00'}},
+    }, {
+        name: 'Extended 7 bit symbols #1',
+        pduStr: '07919730071111F1000B919746121611F10000811170021222230A1B5E583C2697CD1B1F',
+        expectedResult: {
+            data: {size: 10, text: '[abcdef]'},
+        }
+    }, {
+        name: 'UCS2 encoded #1',
+        pduStr: '07919730071111F1000B919746121611F100088111800212222318041F04400438043204350442002C0020043C043804400021',
+        expectedResult: {
+            data: {
+                size: 24,
+                text: '\u041f\u0440\u0438\u0432\u0435\u0442, \u043c\u0438\u0440!', /* Russian: "Hello, world!" */
+            },
+        }
     }, {
         name: 'Concatenated message #1 (part 1/2) with 16bit ref.',
         pduStr: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',

--- a/test.js
+++ b/test.js
@@ -257,6 +257,10 @@ var parserTests = [
         name: 'EMS formatted text #1',
         pduStr: '07919730071111F1400B919746121611F100008111701222322342140A030004100A030606200A030E09400A031C0D80C2379BCC0225E961767ACC0255DDE4B29C9D76974161371934A5CBD3EB321D2D7FD7CF6817',
         expectedResult: {data: {text: 'Bold, Italic, Underline and Strikethrough.'}},
+    }, {
+        name: 'EMS formatted text #2',
+        pduStr: '07919730071111F1400B919746121611F100008111701222822310050A03000410846F3619F476B3F3',
+        expectedResult: {data: {text: 'Bold only'}},
     }
 ];
 

--- a/test.js
+++ b/test.js
@@ -131,6 +131,8 @@ var sevenBitEncodingTests = [
         name: '"@" loss', text: 'abcdefg@', code: '61F1985C369F01', codeLen: 8,
     }, {
         name: 'final "}" decoding error', text: '{test}', code: '1B14BD3CA76F52',
+    }, {
+        name: 'text with alignment', text: 'abc', code: '088BC7', alignBits: 3,
     }
 ];
 
@@ -142,13 +144,13 @@ for (let test of sevenBitEncodingTests) {
 
     cntTotal++;
 
-    out = Helper.encode7Bit(test.text);
+    out = Helper.encode7Bit(test.text, test.alignBits);
     if (out[1] != test.code) {
         passed = false;
         console.log(logPrefix + 'fail: encoder error (text: "' + test.text + '", expecting: "' + test.code + '", got "' + out[1] + '")');
     }
 
-    out = Helper.decode7Bit(test.code, test.codeLen);
+    out = Helper.decode7Bit(test.code, test.codeLen, test.alignBits);
     if (out != test.text) {
         passed = false;
         console.log(logPrefix + 'fail: decoder error (code: "' + test.code + '", expecting: "' + test.text + '", got "' + out + '")');

--- a/test.js
+++ b/test.js
@@ -256,6 +256,20 @@ var parserTests = [
             data: {text: ' man?'},
         },
     }, {
+        name: 'Concatenated message #4 (part 1/2) with 8bit ref.',
+        pduStr: '07919730071111F1400B919746121611F10000100161916223230D0500032E020190E175DD1D06',
+        expectedResult: {
+            udh: {pointer: 0x2e, segments: 2, current: 1},
+            data: {text: 'Hakuna'},
+        },
+    }, {
+        name: 'Concatenated message #4 (part 2/2) with 8bit ref.',
+        pduStr: '07919730071111F1400B919746121611F10000100161916233230E0500032E020240ED303D4C0F03',
+        expectedResult: {
+            udh: {pointer: 0x2e, segments: 2, current: 2},
+            data: {text: ' matata'},
+        },
+    }, {
         name: 'EMS formatted text #1',
         pduStr: '07919730071111F1400B919746121611F100008111701222322342140A030004100A030606200A030E09400A031C0D80C2379BCC0225E961767ACC0255DDE4B29C9D76974161371934A5CBD3EB321D2D7FD7CF6817',
         expectedResult: {data: {text: 'Bold, Italic, Underline and Strikethrough.'}},
@@ -326,6 +340,11 @@ var appendTests = [
         pduStr1: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',
         pduStr2: '07919730071111F1400B919746121611F10000811170021232230C06080412340302A03A9C05',
         expectedError: 'Part from different message',
+    }, {
+        name: 'Concat message with 8bit ref.',
+        pduStr1: '07919730071111F1400B919746121611F10000100161916223230D0500032E020190E175DD1D06',
+        pduStr2: '07919730071111F1400B919746121611F10000100161916233230E0500032E020240ED303D4C0F03',
+        expectedResult: {data: {text: 'Hakuna matata'}},
     }
 ];
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var pdu = require('node-pdu');
+var Helper = pdu.getModule('PDU/Helper');
 
 var testNum;
 var cntTotal = 0;
@@ -64,6 +65,66 @@ function verifyResultPdu(logPrefix, res, expRes, err)
     }
 
     return true;
+}
+
+var sevenBitEncodingTests = [
+    {
+        name: 'Lowercase letters',
+        text: 'abcdefghijklmnopqrstuvwxyz',
+        code: '61F1985C369FD169F59ADD76BFE171F99C5EB7DFF1793D',
+    }, {
+        name: 'Uppercase letters',
+        text: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+        code: '41E19058341E9149E592D9743EA151E9945AB55EB1592D',
+    }, {
+        name: 'Digits',
+        text: '0123456789',
+        code: 'B0986C46ABD96EB81C',
+    }, {
+        name: '1 symbol', text: 'a', code: '61',
+    }, {
+        name: '2 symbols', text: 'ab', code: '6131',
+    }, {
+        name: '3 symbols', text: 'abc', code: '61F118',
+    }, {
+        name: '4 symbols', text: 'abcd', code: '61F1980C',
+    }, {
+        name: '5 symbols', text: 'abcde', code: '61F1985C06',
+    }, {
+        name: '6 symbols', text: 'abcdef', code: '61F1985C3603',
+    }, {
+        name: '7 symbols', text: 'abcdefg', code: '61F1985C369F01',
+    }, {
+        name: '8 symbols', text: 'abcdefgh', code: '61F1985C369FD1',
+    }, {
+        name: '9 symbols', text: 'abcdefghi', code: '61F1985C369FD169',
+    }
+];
+
+testNum = 0;
+for (let test of sevenBitEncodingTests) {
+    var logPrefix = makeLogPrefix('7BitEncoding', ++testNum, test.name);
+    var out = undefined;
+    var passed = true;
+
+    cntTotal++;
+
+    out = Helper.encode7Bit(test.text);
+    if (out[1] != test.code) {
+        passed = false;
+        console.log(logPrefix + 'fail: encoder error (text: "' + test.text + '", expecting: "' + test.code + '", got "' + out[1] + '")');
+    }
+
+    out = Helper.decode7Bit(test.code);
+    if (out != test.text) {
+        passed = false;
+        console.log(logPrefix + 'fail: decoder error (code: "' + test.code + '", expecting: "' + test.text + '", got "' + out + '")');
+    }
+
+    if (passed) {
+        cntOk++;
+        console.log(logPrefix + 'Ok');
+    }
 }
 
 var parserTests = [

--- a/test.js
+++ b/test.js
@@ -196,6 +196,27 @@ var parserTests = [
             udh: {pointer: 0x1235, segments: 2, current: 2},
             data: {text: ' world!'},
         },
+    }, {
+        name: 'Concatenated message #3 (part 1/3) with 16bit ref.',
+        pduStr: '07919730071111F1400B919746121611F10000811170021222230E060804123403015774987E9A03',
+        expectedResult: {
+            udh: {pointer: 0x1234, segments: 3, current: 1},
+            data: {text: 'What\'s'},
+        },
+    }, {
+        name: 'Concatenated message #3 (part 2/3) with 16bit ref.',
+        pduStr: '07919730071111F1400B919746121611F10000811170021232230C06080412340302A03A9C05',
+        expectedResult: {
+            udh: {pointer: 0x1234, segments: 3, current: 2},
+            data: {text: ' up,'},
+        },
+    }, {
+        name: 'Concatenated message #3 (part 3/3) with 16bit ref.',
+        pduStr: '07919730071111F1400B919746121611F10000811170021242230D06080412340303A076D8FD03',
+        expectedResult: {
+            udh: {pointer: 0x1234, segments: 3, current: 3},
+            data: {text: ' man?'},
+        },
     }
 ];
 
@@ -230,6 +251,21 @@ var appendTests = [
         pduStr2: '07919730071111F1400B919746121611F10000811170021222230B06080412350201C8340B',
         expectedResult: {data: {text: 'Hi, world!'}},
     }, {
+        name: 'Simple concatenated message #3, parts 1 & 2',
+        pduStr1: '07919730071111F1400B919746121611F10000811170021222230E060804123403015774987E9A03',
+        pduStr2: '07919730071111F1400B919746121611F10000811170021232230C06080412340302A03A9C05',
+        expectedResult: {data: {text: 'What\'s up,'}},
+    }, {
+        name: 'Simple concatenated message #3, parts 1 & 3',
+        pduStr1: '07919730071111F1400B919746121611F10000811170021222230E060804123403015774987E9A03',
+        pduStr2: '07919730071111F1400B919746121611F10000811170021242230D06080412340303A076D8FD03',
+        expectedResult: {data: {text: 'What\'s man?'}},
+    }, {
+        name: 'Simple concatenated message #3, parts 2 & 3',
+        pduStr1: '07919730071111F1400B919746121611F10000811170021232230C06080412340302A03A9C05',
+        pduStr2: '07919730071111F1400B919746121611F10000811170021242230D06080412340303A076D8FD03',
+        expectedResult: {data: {text: ' up, man?'}},
+    }, {
         name: 'Duplicated parts of a concatenated message',
         pduStr1: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',
         pduStr2: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',
@@ -238,6 +274,11 @@ var appendTests = [
         name: 'Parts of different messages',
         pduStr1: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',
         pduStr2: '07919730071111F1400B919746121611F10000811170021232230F06080412350202A0FB5BCE268700',
+        expectedError: 'Part from different message',
+    }, {
+        name: 'Parts with a collided identifiers',
+        pduStr1: '07919730071111F1400B919746121611F10000811170021222230E06080412340201C8329BFD6601',
+        pduStr2: '07919730071111F1400B919746121611F10000811170021232230C06080412340302A03A9C05',
         expectedError: 'Part from different message',
     }
 ];

--- a/test.js
+++ b/test.js
@@ -304,10 +304,22 @@ for (let test of parserTests) {
         error = e.message;
     }
 
-    if (verifyResultPdu(logPrefix, msg, test.expectedResult, error, test.expectedError)) {
-        cntOk++;
-        console.log(logPrefix + 'Ok');
+    if (!verifyResultPdu(logPrefix, msg, test.expectedResult, error, test.expectedError))
+        continue;
+
+    if (error == '') {
+        var resPdu = msg.getData().getParts()[0].toString();
+
+        if (test.pduStr != resPdu) {
+            console.log(logPrefix + 'fail: recreation mangles the PDU');
+            console.log(logPrefix + 'origin: ' + test.pduStr);
+            console.log(logPrefix + 'result: ' + resPdu);
+            continue;
+        }
     }
+
+    cntOk++;
+    console.log(logPrefix + 'Ok');
 }
 
 var appendTests = [

--- a/test.js
+++ b/test.js
@@ -73,6 +73,10 @@ function verifyResultPdu(logPrefix, res, expRes, err, expErr)
             if (!verifyPduValue(logPrefix, 'phone', res, 'getAddress().getPhone()', expRes.address.phone))
                 return false;
         }
+        if (expRes.dcs !== undefined) {
+            if (!verifyPduValue(logPrefix, 'DCS value', res, 'getDcs().getValue()', expRes.dcs.value))
+                return false;
+        }
         if (expRes.scts !== undefined) {
             if (!verifyPduValue(logPrefix, 'timestamp', res, 'getScts().getIsoString()', expRes.scts.isoStr))
                 return false;
@@ -277,6 +281,13 @@ var parserTests = [
         name: 'EMS formatted text #2',
         pduStr: '07919730071111F1400B919746121611F100008111701222822310050A03000410846F3619F476B3F3',
         expectedResult: {data: {text: 'Bold only'}},
+    }, {
+        name: 'Flash SMS',
+        pduStr: '07919730071111F1000B919746121611F10010811170021222231054747A0E4ACF416190991D9EA343',
+        expectedResult: {
+            dcs: {value: 0x10},
+            data: {text: 'This is a flash!'},
+        },
     }
 ];
 

--- a/test.js
+++ b/test.js
@@ -253,6 +253,10 @@ var parserTests = [
             udh: {pointer: 0x1234, segments: 3, current: 3},
             data: {text: ' man?'},
         },
+    }, {
+        name: 'EMS formatted text #1',
+        pduStr: '07919730071111F1400B919746121611F100008111701222322342140A030004100A030606200A030E09400A031C0D80C2379BCC0225E961767ACC0255DDE4B29C9D76974161371934A5CBD3EB321D2D7FD7CF6817',
+        expectedResult: {data: {text: 'Bold, Italic, Underline and Strikethrough.'}},
     }
 ];
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,105 @@
+var pdu = require('node-pdu');
+
+var testNum;
+var cntTotal = 0;
+var cntOk = 0;
+
+function makeLogPrefix(testType, testNum, testName)
+{
+    var str = '';
+
+    if (testType !== undefined)
+        str += testType;
+    if (testNum !== undefined)
+        str += '#' + testNum;
+    if (testName !== undefined)
+        str += str == '' ? testName : ' (' + testName + ')';
+    if (str == '')
+        str = 'Unknown';
+
+    return str + ': ';
+}
+
+function verifyPduValue(logPrefix, valName, pdu, expr, expVal)
+{
+    if (expVal === undefined)
+        return true;
+
+    var val = eval('pdu.' + expr);
+
+    if (val === expVal)
+        return true;
+
+    console.log(logPrefix + 'fail: unexpected ' + valName + ' value (expected: "' + expVal + '", got: "' + val + '")');
+
+    return false;
+}
+
+function verifyResultPdu(logPrefix, res, expRes, err)
+{
+    if (err) {
+        console.log(logPrefix + 'fail: got an error: ' + err);
+        return false;
+    } else if (expRes) {
+        if (expRes.sca !== undefined) {
+            if (!verifyPduValue(logPrefix, 'SCA address attribute', res, 'getSca().isAddress()', expRes.sca.isAddress))
+                return false;
+            if (!verifyPduValue(logPrefix, 'SCA', res, 'getSca().getPhone()', expRes.sca.phone))
+                return false;
+        }
+        if (expRes.address !== undefined) {
+            if (!verifyPduValue(logPrefix, 'OA/DA address attribute', res, 'getAddress().isAddress()', expRes.address.isAddress))
+                return false;
+            if (!verifyPduValue(logPrefix, 'phone', res, 'getAddress().getPhone()', expRes.address.phone))
+                return false;
+        }
+        if (expRes.scts !== undefined) {
+            if (!verifyPduValue(logPrefix, 'timestamp', res, 'getScts().getIsoString()', expRes.scts.isoStr))
+                return false;
+        }
+        if (expRes.data !== undefined) {
+            if (!verifyPduValue(logPrefix, 'text', res, 'getData().getText()', expRes.data.text))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+var parserTests = [
+    {
+        name: 'Simple Delivery message #1',
+        pduStr: '07919730071111F1000B919746121611F10000811170021222230DC8329BFD6681EE6F399B1C02',
+        expectedResult: {
+            sca: {isAddress: false, phone: '79037011111'},
+            address: {isAddress: true, phone: '79642161111'},
+            scts: {isoStr: '2018-11-07T20:21:22+08:00'},
+            data: {text: 'Hello, world!'},
+        },
+    }, {
+        name: 'Negative SCTS Time Zone offset',
+        pduStr: '07919730071111F1000B919746121611F100008111700212222B0DC8329BFD6681EE6F399B1C02',
+        expectedResult: {scts: {isoStr: '2018-11-07T20:21:22-08:00'}},
+    }
+];
+
+testNum = 0;
+for (let test of parserTests) {
+    var logPrefix = makeLogPrefix('parser', ++testNum, test.name);
+    var error = '';
+    var msg = undefined;
+
+    cntTotal++;
+    try {
+        msg = pdu.parse(test.pduStr);
+    } catch (e) {
+        error = e.message;
+    }
+
+    if (verifyResultPdu(logPrefix, msg, test.expectedResult, error)) {
+        cntOk++;
+        console.log(logPrefix + 'Ok');
+    }
+}
+
+console.log('Perform ' + cntTotal + ' test(s): ' + cntOk + ' Ok ' + (cntTotal - cntOk) + ' fail');

--- a/test.js
+++ b/test.js
@@ -129,6 +129,8 @@ var sevenBitEncodingTests = [
         name: '9 symbols', text: 'abcdefghi', code: '61F1985C369FD169',
     }, {
         name: '"@" loss', text: 'abcdefg@', code: '61F1985C369F01', codeLen: 8,
+    }, {
+        name: 'final "}" decoding error', text: '{test}', code: '1B14BD3CA76F52',
     }
 ];
 
@@ -177,6 +179,12 @@ var parserTests = [
         pduStr: '07919730071111F1000B919746121611F10000811170021222230A1B5E583C2697CD1B1F',
         expectedResult: {
             data: {size: 10, text: '[abcdef]'},
+        }
+    }, {
+        name: 'Extended 7 bit symbols #2',
+        pduStr: '07919730071111F1000B919746121611F1000081117002122223081B14BD3CA76F52',
+        expectedResult: {
+            data: {size: 8, text: '{test}'},
         }
     }, {
         name: 'UCS2 encoded #1',


### PR DESCRIPTION
The goal of this changes set is to improve the parsing ability. But it also includes several fixes for the PDUs generation, changes which make code a bit more clear and introduces a script to facilitate testing procedures.

Most changes are made to the Header and Data classes - they can now parse (and generate) UDHs of arbitrary content. The encoder and decoder of the 7-bit alphabet were reworked to support the encoded stream length and to be an align bits aware.

I did my best to preserve the default behaviour, but the default behaviour of the Header class was a bit changed (see details in the commit messages).

All test vectors are synthetic. They are all hand crafted (and verified with an available PDU handling tools, including various online services). I tried to use real PDUs (e.g. from the Internet), but they are not well suitable to testing, since they either contain a sensless data or are simply too loooong.