### PR TITLE
fix: SCA parser for lowercase inputs

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -19,7 +19,7 @@ import parseVP from './parseUtils/parseVP';
 export type GetSubstr = (length: number) => string;
 
 export function parse(str: string) {
-	let pduParse = str;
+	let pduParse = str.toUpperCase();
 
 	const getSubstr: GetSubstr = (length: number) => {
 		const str = pduParse.substring(0, length);


### PR DESCRIPTION
This change fixes SCA Parser for cases when the input is not capitalized. A lower-case input would not have it's padding char detected, which causes the size to be wrongly computed and the padding char being included in the final phone result